### PR TITLE
Need to reset input and fieldset height and line-height for bootstrap

### DIFF
--- a/styles/src/skeuocard.reset.scss
+++ b/styles/src/skeuocard.reset.scss
@@ -49,4 +49,7 @@
       border-collapse:collapse;
       border-spacing:0;
   }
+  input,fieldset{
+      line-height:normal;
+      height:1.5em;
 }


### PR DESCRIPTION
Bootstrap 2.3 changes these values, making the input fields miss half their vertical content and mis-align the placeholder text.

Apart from that, it seems to work with Bootstrap 2.3 for me.
