### PR TITLE
Fixed typo in bower.json, there was a missing semicolon

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "styles/skeuocard.reset.css",
     "styles/skeuocard.css",
     "javascripts/vendor/css_browser_selector.js",
-    "javascripts/skeuocard.js"
+    "javascripts/skeuocard.js",
     "javascripts/skeuocard.min.js"
   ],
   "ignore": [


### PR DESCRIPTION
It looks like bower.json was missing a semicolon, causing bower install to fail.
