### PR TITLE
Maestro (MasterCard) BIN Definition Add

### DIFF
--- a/javascripts/skeuocard.js
+++ b/javascripts/skeuocard.js
@@ -1646,7 +1646,7 @@
   });
 
   Skeuocard.prototype.CardProduct.create({
-    pattern: /^(5018|5020|5038|6304|6759|676[1-3])/,
+    pattern: /^(5018|5020|5038|6304|6759|6711|676[1-3])/,
     companyName: "Maestro (MasterCard)",
     companyShortname: "maestro",
     cardNumberGrouping: [4, 4, 4, 4],


### PR DESCRIPTION
I added BIN number into to regex. When card number start with '6711' in input, card is undefined. This BIN number of Aktif Bank Passolig Card (Turkish Bank). For BIN check  => https://www.freebinchecker.com/bin-lookup/671121